### PR TITLE
Add functionality to change length of files in mcb1.bln and adjust offsets in blnsub files based on changes in external bin archives

### DIFF
--- a/HaruhiHeiretsuCLI/Program.cs
+++ b/HaruhiHeiretsuCLI/Program.cs
@@ -258,9 +258,9 @@ namespace HaruhiHeiretsuCLI
 
             XmlElement options = xml.CreateElement("options");
             XmlElement section = xml.CreateElement("section");
-            section.SetAttribute("name", "Heiretsu Replacement");
+            section.SetAttribute("name", "Heiretsu Translation");
             XmlElement option = xml.CreateElement("option");
-            option.SetAttribute("name", "Heiretsu Replacement");
+            option.SetAttribute("name", "Heiretsu Translation");
             XmlElement choice = xml.CreateElement("choice");
             choice.SetAttribute("name", "Enabled");
             XmlElement choicePatch = xml.CreateElement("patch");

--- a/HaruhiHeiretsuEditor/MainWindow.xaml
+++ b/HaruhiHeiretsuEditor/MainWindow.xaml
@@ -11,6 +11,7 @@
             <MenuItem Header="File">
                 <MenuItem x:Name="menuOpenMcb" Header="Open MCB" Click="MenuOpenMcb_Click" />
                 <MenuItem x:Name="menuSaveMcb" Header="Save MCB" Click="MenuSaveMcb_Click" />
+                <MenuItem x:Name="menuAdjustMcb" Header="Adjust MCB Offsets" Click="MenuAdjustMcb_Click" />
             </MenuItem>
         </Menu>
         <TabControl x:Name="mainTabControl" Height="453">

--- a/HaruhiHeiretsuEditor/MainWindow.xaml.cs
+++ b/HaruhiHeiretsuEditor/MainWindow.xaml.cs
@@ -73,6 +73,30 @@ namespace HaruhiHeiretsuEditor
             }
         }
 
+        private void MenuAdjustMcb_Click(object sender, RoutedEventArgs e)
+        {
+            if (_mcb is not null)
+            {
+                SaveFileDialog mcbSaveFileDialog = new()
+                {
+                    Filter = "MCB0|mcb0.bln",
+                    Title = "Save MCBs"
+                };
+                if (mcbSaveFileDialog.ShowDialog() == true)
+                {
+                    OpenFileDialog offsetOpenFileDialog = new()
+                    {
+                        Filter = "CSV|*.csv",
+                        Title = "Open Offset Adjustments CSV"
+                    };
+                    if (offsetOpenFileDialog.ShowDialog() == true)
+                    {
+                        _mcb.AdjustOffsets(mcbSaveFileDialog.FileName, mcbSaveFileDialog.FileName.Replace("0", "1"), offsetOpenFileDialog.FileName).GetAwaiter().GetResult();
+                    }
+                }
+            }
+        }
+
         private void OpenScrFileButton_Click(object sender, RoutedEventArgs e)
         {
             OpenFileDialog openFileDialog = new()
@@ -95,7 +119,13 @@ namespace HaruhiHeiretsuEditor
             };
             if (saveFileDialog.ShowDialog() == true)
             {
-                File.WriteAllBytes(saveFileDialog.FileName, _scrFile.GetBytes());
+                File.WriteAllBytes(saveFileDialog.FileName, _scrFile.GetBytes(out Dictionary<int, int> offsetAdjustments));
+                string offsetAdjustmentsFile = "scr.bin";
+                foreach(int originalOffset in offsetAdjustments.Keys)
+                {
+                    offsetAdjustmentsFile += $"\n{originalOffset},{offsetAdjustments[originalOffset]}";
+                }
+                File.WriteAllText($"{saveFileDialog.FileName}_offset_adjustments.csv", offsetAdjustmentsFile);
             }
         }
 
@@ -187,7 +217,13 @@ namespace HaruhiHeiretsuEditor
             };
             if (saveFileDialog.ShowDialog() == true)
             {
-                File.WriteAllBytes(saveFileDialog.FileName, _grpFile.GetBytes());
+                File.WriteAllBytes(saveFileDialog.FileName, _grpFile.GetBytes(out Dictionary<int, int> offsetAdjustments));
+                string offsetAdjustmentsFile = "grp.bin";
+                foreach (int originalOffset in offsetAdjustments.Keys)
+                {
+                    offsetAdjustmentsFile += $"\n{originalOffset},{offsetAdjustments[originalOffset]}";
+                }
+                File.WriteAllText($"{saveFileDialog.FileName}_offset_adjustments.csv", offsetAdjustmentsFile);
             }
         }
 
@@ -230,6 +266,14 @@ namespace HaruhiHeiretsuEditor
             if (graphicsListBox.SelectedIndex >= 0)
             {
                 GraphicsFile selectedFile = (GraphicsFile)graphicsListBox.SelectedItem;
+                if (_grpFile is not null)
+                {
+                    graphicsEditStackPanel.Children.Add(new TextBlock
+                    {
+                        Text = $"Actual compressed length: {selectedFile.CompressedData.Length:X}; Calculated length: {selectedFile.Length:X}",
+                        Background = System.Windows.Media.Brushes.White
+                    });
+                }
                 if (selectedFile.FileType == GraphicsFile.GraphicsFileType.SGE)
                 {
                     graphicsEditStackPanel.Children.Add(new TextBlock { Text = $"SGE {selectedFile.Data.Count} bytes" });

--- a/HaruhiHeiretsuLib/ArchiveFile.cs
+++ b/HaruhiHeiretsuLib/ArchiveFile.cs
@@ -90,8 +90,6 @@ namespace HaruhiHeiretsuLib
                 fileBytes.AddRange(nextLine);
                 if (fileBytes.Count > 0)
                 {
-                    fileBytes.AddRange(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 });
-
                     T file = new();
                     try
                     {
@@ -202,9 +200,11 @@ namespace HaruhiHeiretsuLib
             return offsetComponent | (uint)newLengthComponent;
         }
 
-        public byte[] GetBytes()
+        public byte[] GetBytes(out Dictionary<int, int> offsetAdjustments)
         {
             List<byte> bytes = new();
+            offsetAdjustments = new();
+            offsetAdjustments.Add(Files[0].Offset, Files[0].Offset);
 
             bytes.AddRange(Header);
             for (int i = 0; i < Files.Count; i++)
@@ -228,6 +228,7 @@ namespace HaruhiHeiretsuLib
                 bytes.AddRange(compressedBytes);
                 if (i < Files.Count - 1)
                 {
+                    int originalOffset = Files[i + 1].Offset;
                     int pointerShift = 0;
                     while (bytes.Count % 0x10 != 0)
                     {
@@ -251,6 +252,7 @@ namespace HaruhiHeiretsuLib
                     {
                         bytes.Add(0);
                     }
+                    offsetAdjustments.Add(originalOffset, Files[i + 1].Offset);
                 }
             }
             while (bytes.Count % 0x800 != 0)

--- a/HaruhiHeiretsuLib/McbFile.cs
+++ b/HaruhiHeiretsuLib/McbFile.cs
@@ -102,6 +102,14 @@ namespace HaruhiHeiretsuLib
                     archiveIndexToAdjust = 0;
                     break;
 
+                case "dat.bin":
+                    archiveIndexToAdjust = 1;
+                    break;
+
+                case "scr.bin":
+                    archiveIndexToAdjust = 2;
+                    break;
+
                 default:
                     Console.WriteLine($"Invalid archive loaded: {binArchiveAdjustmentFile}");
                     return;

--- a/KuriimuBlnPort/BlnSupport/Archives/Bln.cs
+++ b/KuriimuBlnPort/BlnSupport/Archives/Bln.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using Komponent.IO;
 using Komponent.IO.Streams;
 using Kontract.Models.Archive;

--- a/KuriimuBlnPort/BlnSupport/Archives/BlnSub.cs
+++ b/KuriimuBlnPort/BlnSupport/Archives/BlnSub.cs
@@ -82,7 +82,7 @@ namespace plugin_shade.Archives
             return result;
         }
 
-        public void Save(Stream output, IList<IArchiveFileInfo> files, bool leaveOpen = false)
+        public void Save(Stream output, IList<IArchiveFileInfo> files, int archiveIndexToAdjust = -1, IDictionary<int, int> offsetAdjustments = null, bool leaveOpen = false)
         {
             // Write files
             using var bw = new BinaryWriterX(output, leaveOpen: leaveOpen);
@@ -92,6 +92,11 @@ namespace plugin_shade.Archives
                 output.Position += 0xC;
 
                 long writtenSize = file.SaveFileData(output);
+
+                if (archiveIndexToAdjust == file.Entry.archiveIndex && offsetAdjustments != null)
+                {
+                    file.Entry.archiveOffset = offsetAdjustments[file.Entry.archiveOffset];
+                }
 
                 file.Entry.size = (int)writtenSize;
                 long endOffset = startOffset + writtenSize + 0xC;

--- a/KuriimuBlnPort/BlnSupport/Archives/BlnSub.cs
+++ b/KuriimuBlnPort/BlnSupport/Archives/BlnSub.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -15,25 +16,29 @@ namespace plugin_shade.Archives
     {
         public IList<IArchiveFileInfo> Load(Stream input)
         {
-            using var br = new BinaryReaderX(input, true);
+            using BinaryReaderX br = new BinaryReaderX(input, true);
 
             // Read files
             var result = new List<IArchiveFileInfo>();
 
-            var index = 0;
+            int index = 0;
             while (br.BaseStream.Position < input.Length)
             {
-                var sample = br.ReadInt32();
+                int sample = br.ReadInt32();
                 if (sample == 0x7FFF)
+                {
                     break;
+                }
 
                 br.BaseStream.Position -= 4;
-                var entry = br.ReadType<BlnSubEntry>();
+                BlnSubEntry entry = br.ReadType<BlnSubEntry>();
 
                 if (entry.size == 0)
+                {
                     break;
+                }
 
-                var stream = new SubStream(input, br.BaseStream.Position, entry.size);
+                SubStream stream = new SubStream(input, br.BaseStream.Position, entry.size);
                 result.Add(CreateAfi(stream, index++, entry));
 
                 br.BaseStream.Position += entry.size;
@@ -51,12 +56,12 @@ namespace plugin_shade.Archives
             int index = 0;
             while (br.BaseStream.Position < input.Length)
             {
-                var sample = br.ReadInt32();
+                int sample = br.ReadInt32();
                 if (sample == 0x7FFF)
                     break;
 
                 br.BaseStream.Position -= 4;
-                var entry = br.ReadType<BlnSubEntry>();
+                BlnSubEntry entry = br.ReadType<BlnSubEntry>();
 
                 if (entry.size == 0)
                     break;
@@ -83,12 +88,13 @@ namespace plugin_shade.Archives
             using var bw = new BinaryWriterX(output, leaveOpen: leaveOpen);
             foreach (var file in files.Cast<BlnSubArchiveFileInfo>())
             {
-                var startOffset = output.Position;
+                long startOffset = output.Position;
                 output.Position += 0xC;
 
-                var writtenSize = file.SaveFileData(output);
+                long writtenSize = file.SaveFileData(output);
 
-                var endOffset = startOffset + writtenSize + 0xC;
+                file.Entry.size = (int)writtenSize;
+                long endOffset = startOffset + writtenSize + 0xC;
                 output.Position = startOffset;
                 bw.WriteType(file.Entry);
 

--- a/KuriimuBlnPort/BlnSupport/Archives/BlnSubSupport.cs
+++ b/KuriimuBlnPort/BlnSupport/Archives/BlnSubSupport.cs
@@ -14,6 +14,8 @@ namespace plugin_shade.Archives
 
     // For Suzumiya Haruhi no Heiretsu
     // 0x00 => grp.bin
+    // 0x01 => dat.bin
+    // 0x02 => scr.bin
 
     public class BlnSubEntry
     {

--- a/KuriimuBlnPort/BlnSupport/Archives/BlnSubSupport.cs
+++ b/KuriimuBlnPort/BlnSupport/Archives/BlnSubSupport.cs
@@ -12,6 +12,9 @@ namespace plugin_shade.Archives
     // 0x04 => dat.bin
     // 0x05 => grp.bin?
 
+    // For Suzumiya Haruhi no Heiretsu
+    // 0x00 => grp.bin
+
     public class BlnSubEntry
     {
         public int archiveIndex;    // index to an external bin

--- a/KuriimuBlnPort/BlnSupport/Archives/ShadeSupport.cs
+++ b/KuriimuBlnPort/BlnSupport/Archives/ShadeSupport.cs
@@ -120,11 +120,14 @@ namespace plugin_shade.Archives
             long writtenSize = base.SaveFileData(output, compress, progress);
 
             // Pad to % 800
-            long paddedSize = 800 - (writtenSize % 800);
-            byte[] padding = new byte[paddedSize];
-            output.Write(padding, 0, padding.Length);
+            long paddedSize = 0x800 - (writtenSize % 0x800);
+            if (paddedSize != 0x800)
+            {
+                byte[] padding = new byte[paddedSize];
+                output.Write(padding, 0, padding.Length);
 
-            writtenSize += paddedSize;
+                writtenSize += paddedSize;
+            }
 
             // Return padded size as written
             return writtenSize;

--- a/KuriimuBlnPort/BlnSupport/Archives/ShadeSupport.cs
+++ b/KuriimuBlnPort/BlnSupport/Archives/ShadeSupport.cs
@@ -117,20 +117,14 @@ namespace plugin_shade.Archives
 
         public override long SaveFileData(Stream output, bool compress, IProgressContext progress = null)
         {
-            var writtenSize = base.SaveFileData(output, compress, progress);
+            long writtenSize = base.SaveFileData(output, compress, progress);
 
-            if (writtenSize > OriginalSize)
-                throw new InvalidOperationException("The replaced file cannot be larger than its original.");
+            // Pad to % 800
+            long paddedSize = 800 - (writtenSize % 800);
+            byte[] padding = new byte[paddedSize];
+            output.Write(padding, 0, padding.Length);
 
-            // Pad to original size
-            var paddedSize = OriginalSize - writtenSize;
-            if (paddedSize > 0)
-            {
-                var padding = new byte[paddedSize];
-                output.Write(padding, 0, padding.Length);
-
-                writtenSize += paddedSize;
-            }
+            writtenSize += paddedSize;
 
             // Return padded size as written
             return writtenSize;


### PR DESCRIPTION
This adds a few changes.

1) We remove Kuriimu's restriction on increasing compressed file sizes and add logic to adjust file length in the archive entry.
2) In order to facilitate changing bin archive file size and pointers, we add an intermediary step, emitting a file containing the offset changes of all files in the bin
3) We then add a function to consume this intermediary file to adjust all offsets in the mcb file.